### PR TITLE
Updated 'desc' snippet and a few new entries

### DIFF
--- a/align.yasnippet
+++ b/align.yasnippet
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# contributor : Rasmus Borgsmidt <rasmus@borgsmidt.dk>
+# key : align
+# group: environments
+# name : \begin{align} ... \end{align}
+# --
+\begin{align}
+\item $0
+\end{align}

--- a/align.yasnippet
+++ b/align.yasnippet
@@ -5,5 +5,5 @@
 # name : \begin{align} ... \end{align}
 # --
 \begin{align}
-\item $0
+  $0
 \end{align}

--- a/alignstar.yasnippet
+++ b/alignstar.yasnippet
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# contributor : Rasmus Borgsmidt <rasmus@borgsmidt.dk>
+# key : align*
+# group: environments
+# name : \begin{align*} ... \end{align*}
+# --
+\begin{align*}
+\item $0
+\end{align*}

--- a/alignstar.yasnippet
+++ b/alignstar.yasnippet
@@ -5,5 +5,5 @@
 # name : \begin{align*} ... \end{align*}
 # --
 \begin{align*}
-\item $0
+  $0
 \end{align*}

--- a/desc.yasnippet
+++ b/desc.yasnippet
@@ -5,5 +5,5 @@
 # name : \begin{description} ... \end{description}
 # --
 \begin{description}
-\item[$0]
+\item[${1:label}] $0
 \end{description}

--- a/itd.yasnippet
+++ b/itd.yasnippet
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# contributor: Rasmus Borgsmidt <rasmus@borgsmidt.dk>
+# key: itd
+# group: environments
+# name: \item[] (description)
+# --
+\item[${1:label}] $0

--- a/sc.yasnippet
+++ b/sc.yasnippet
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# contributor: Rasmus Borgsmidt <rasmus@borgsmidt.dk>
+# key: sc
+# group: font
+# name: {\sc ...}
+# --
+{\scshape $1}$0


### PR DESCRIPTION
#### Update

introduce separate _label_ stage in `desc` snippet before exit.  This makes the workflow: `desc` `TAB` _first item label_ `TAB` _first item text_

Subsequent items can be added with the new `itd` snippet: `itd` `TAB` _item label_ `TAB` _item text_
#### New snippets:

`sc` (small caps)
`align` (_align_ math env)
`alignstar` (_align*_ math env)
`itd` (labelled item for description env)
